### PR TITLE
Update Slack plugin

### DIFF
--- a/app_image_generator/plugins/slack.py
+++ b/app_image_generator/plugins/slack.py
@@ -1,4 +1,4 @@
-import os
+import os, requests
 from app_image_generator.plugins.base import BasePlugin
 
 
@@ -7,7 +7,7 @@ class SlackPlugin(BasePlugin):
         self.webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
 
     def build_succeeded(self, app, output):
-        requests.post(self.webhook_url, data({
+        requests.post(self.webhook_url, data={
             "attachments": [{
                 "pretext": f"New {app} images available",
                 "fields": [
@@ -18,12 +18,12 @@ class SlackPlugin(BasePlugin):
                     } for image_name, image_id in self.get_images_from_output(output).items()
                 ],
             }]
-        }))
+        })
 
     def build_failed(self, app, output):
-        requests.post(self.webhook_url, data({
+        requests.post(self.webhook_url, data={
             "attachments": [{
-                "pretext": f"Building %s failed!!!!",
+                "pretext": f"Building {app} failed!!!!",
                 "color": "#F35A00",
                 "fields": [
                     {
@@ -33,4 +33,4 @@ class SlackPlugin(BasePlugin):
                     } for image_name, image_id in self.get_images_from_output(output).items()
                 ],
             }]
-        }))
+        })

--- a/app_image_generator/plugins/slack.py
+++ b/app_image_generator/plugins/slack.py
@@ -1,16 +1,15 @@
 import os
-from slacker import Slacker
 from app_image_generator.plugins.base import BasePlugin
 
 
 class SlackPlugin(BasePlugin):
     def __init__(self):
-        self.slacker = Slacker(os.environ.get("SLACK_TOKEN"))
-        self.channel = os.environ.get("SLACK_CHANNEL")
+        self.webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
 
     def build_succeeded(self, app, output):
-        self.slacker.chat.post_message(self.channel or '#dev', 'New %s images available:' % app, username='app-image-generator', attachments=[
-            {
+        requests.post(self.webhook_url, data({
+            "attachments": [{
+                "pretext": f"New {app} images available",
                 "fields": [
                     {
                         "title": image_name,
@@ -18,12 +17,14 @@ class SlackPlugin(BasePlugin):
                         "short": True
                     } for image_name, image_id in self.get_images_from_output(output).items()
                 ],
-            }
-        ])
+            }]
+        }))
 
     def build_failed(self, app, output):
-        self.slacker.chat.post_message(self.channel or '#dev', 'Building %s failed!!!!' % app, username='app-image-generator', attachments=[
-            {
+        requests.post(self.webhook_url, data({
+            "attachments": [{
+                "pretext": f"Building %s failed!!!!",
+                "color": "#F35A00",
                 "fields": [
                     {
                         "title": image_name,
@@ -31,6 +32,5 @@ class SlackPlugin(BasePlugin):
                         "short": True
                     } for image_name, image_id in self.get_images_from_output(output).items()
                 ],
-                "color": "#F35A00"
-            }
-        ])
+            }]
+        }))

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     zip_safe=False,
     include_package_data = True,
     packages = find_packages(exclude=[]),
-    install_requires=['slacker', 'requests'],
+    install_requires=['requests'],
     entry_points={
         'console_scripts': [
             'app-image-generator = app_image_generator.cli:main',


### PR DESCRIPTION
Remove the dependency on the unmaintained Slacker library and Slack access tokens which are also deprecated.

Use slack web hooks instead, which are easy to configure